### PR TITLE
Fix scheduler init compatibility

### DIFF
--- a/siaug/utils/simsiam.py
+++ b/siaug/utils/simsiam.py
@@ -10,8 +10,12 @@ class CosineScheduler(_LRScheduler):
 
         # last epoch should always be -1, use load_state_dict to resume
         # PyTorch 2.0 uses keyword-only arguments for last_epoch and verbose,
-        # so pass them explicitly to support newer versions
-        super().__init__(optimizer, last_epoch=-1, verbose=verbose)
+        # but older versions do not support the ``verbose`` argument. Try to
+        # pass it first and fall back to a compatible call if it fails.
+        try:
+            super().__init__(optimizer, last_epoch=-1, verbose=verbose)
+        except TypeError:
+            super().__init__(optimizer, last_epoch=-1)
 
     def _compute_lr(self, param_group):
         init_lr = param_group["initial_lr"]


### PR DESCRIPTION
## Summary
- use try/except when calling `super().__init__` in `CosineScheduler`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684284f2f9b88330ab1456b3e7345f04