### PR TITLE
Add NIH linear eval config

### DIFF
--- a/configs/experiment/nih_lcls.yaml
+++ b/configs/experiment/nih_lcls.yaml
@@ -1,0 +1,61 @@
+# @package _global_
+
+defaults:
+  - override /dataloader: nih.yaml
+  - override /model: lincls.yaml
+  - override /criterion: bce.yaml
+  - override /metrics: nih.yaml
+
+# general settings
+task_name: lcls_nih_baseline
+max_epoch: 90
+
+# override dataloader settings
+dataloader:
+  train:
+    batch_size: 256
+    dataset:
+      com_transform:
+        _target_: siaug.augmentations.ExtractKeys
+        keys: ["img", "lbl"]
+      img_transform:
+        _target_: torchvision.transforms.Compose
+        transforms:
+          - _target_: torchvision.transforms.RandomResizedCrop
+            size: 224
+          - _target_: torchvision.transforms.RandomHorizontalFlip
+          - _target_: torchvision.transforms.ToTensor
+          - _target_: torchvision.transforms.Normalize
+            mean: [0.50551915, 0.50551915, 0.50551915]
+            std: [0.2895694, 0.2895694, 0.2895694]
+
+  valid:
+    batch_size: 256
+    dataset:
+      com_transform:
+        _target_: siaug.augmentations.ExtractKeys
+        keys: ["img", "lbl"]
+      img_transform:
+        _target_: torchvision.transforms.Compose
+        transforms:
+          - _target_: torchvision.transforms.Resize
+            size: [256, 256]
+          - _target_: torchvision.transforms.CenterCrop
+            size: 224
+          - _target_: torchvision.transforms.ToTensor
+          - _target_: torchvision.transforms.Normalize
+            mean: [0.50551915, 0.50551915, 0.50551915]
+            std: [0.2895694, 0.2895694, 0.2895694]
+
+# override model settings
+model:
+  backbone: ???
+  num_channels: 3
+  num_classes: 15
+  ckpt_path: ???
+
+# optimizer for linear eval
+optimizer:
+  lr: 30
+  weight_decay: 0
+  momentum: 0.9

--- a/configs/metrics/nih.yaml
+++ b/configs/metrics/nih.yaml
@@ -1,0 +1,4 @@
+- - "AUROC@Multilabel"
+  - _partial_: true
+    _target_: torchmetrics.functional.classification.multilabel_auroc
+    num_labels: 15


### PR DESCRIPTION
## Summary
- enable NIH linear evaluation via new experiment config
- add metrics config for NIH dataset

## Testing
- `python check.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6842d0ec3c648330a57a4d7dfc6691a1