### PR TITLE
Fix metrics dtype

### DIFF
--- a/siaug/utils/eval.py
+++ b/siaug/utils/eval.py
@@ -54,7 +54,7 @@ def lcls_eval(
 
             output, targets = accelerator.gather_for_metrics((output, targets))
             for idx, (_, metric) in enumerate(metrics):
-                _metrics[idx].update(metric(output, targets).item(), images.size(0))
+                _metrics[idx].update(metric(output, targets.long()).item(), images.size(0))
 
             # measure elapsed time
             batch_time.update(time() - end)

--- a/siaug/utils/lcls.py
+++ b/siaug/utils/lcls.py
@@ -56,7 +56,7 @@ def lcls_epoch(
 
         # update metrics
         for idx, (_, metric) in enumerate(metrics):
-            _metrics[idx].update(metric(output, targets).item(), images.size(0))
+            _metrics[idx].update(metric(output, targets.long()).item(), images.size(0))
 
         # compute gradient and do SGD step
         optimizer.zero_grad()


### PR DESCRIPTION
## Summary
- cast targets to `long` when computing metrics in linear evaluation helpers

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6843e8ea0a0c8330b87416ea828a833c