### PR TITLE
Fix metrics dtype in lcls_eval

### DIFF
--- a/siaug/utils/eval.py
+++ b/siaug/utils/eval.py
@@ -54,7 +54,9 @@ def lcls_eval(
 
             output, targets = accelerator.gather_for_metrics((output, targets))
             for idx, (_, metric) in enumerate(metrics):
-                _metrics[idx].update(metric(output, targets).item(), images.size(0))
+                _metrics[idx].update(
+                    metric(output, targets.long()).item(), images.size(0)
+                )
 
             # measure elapsed time
             batch_time.update(time() - end)


### PR DESCRIPTION
## Summary
- ensure metrics in `lcls_eval` use integer targets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68444891ee78833082abcf6c2b51cd5f