### PR TITLE
Fix NIH dataset dtype

### DIFF
--- a/siaug/dataloaders/components/nih_dataset.py
+++ b/siaug/dataloaders/components/nih_dataset.py
@@ -80,10 +80,14 @@ class NIHDataset(Dataset):
             lbls = [lb.strip() for lb in labels.split("|")]
             return [1 if c in lbls else 0 for c in columns]
 
-        lbls = df.get_column("Finding Labels").map_elements(encode_labels).to_list()
+        lbls = (
+            df.get_column("Finding Labels")
+            .map_elements(encode_labels, return_dtype=pl.List(pl.Int8))
+            .to_list()
+        )
         imgs = (
             df.get_column("Image Index")
-            .map_elements(lambda x: os.path.join(images_dir, x))
+            .map_elements(lambda x: os.path.join(images_dir, x), return_dtype=pl.Utf8)
             .to_list()
         )
         self.samples = list(zip(imgs, lbls))


### PR DESCRIPTION
## Summary
- set `return_dtype` when mapping label lists and image paths in `NIHDataset`

## Testing
- `pre-commit run --files siaug/dataloaders/components/nih_dataset.py`
- `python - <<'PY'
import importlib.util, os
spec = importlib.util.spec_from_file_location('nih_dataset', os.path.join('siaug','dataloaders','components','nih_dataset.py'))
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
NIHDataset = mod.NIHDataset
csv_path='/tmp/test.csv'
images_dir='/tmp/images'
ds = NIHDataset(csv_path=csv_path, images_dir=images_dir)
print('len', len(ds))
print('first_lbl', ds[0]['lbl'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_684448bb7cc88330bf1e78ab15771122