### PR TITLE
Fix FocalLoss init for non-tensor weights

### DIFF
--- a/siaug/losses/__init__.py
+++ b/siaug/losses/__init__.py
@@ -98,8 +98,20 @@ class FocalLoss(nn.Module):
         super().__init__()
         self.gamma = gamma
         self.reduction = reduction
+
+        if weight is not None and not isinstance(weight, torch.Tensor):
+            weight = torch.tensor(weight, dtype=torch.float)
+
+        if pos_weight is not None and not isinstance(pos_weight, torch.Tensor):
+            pos_weight = torch.tensor(pos_weight, dtype=torch.float)
+
+        self.register_buffer("weight", weight if weight is not None else None)
+        self.register_buffer("pos_weight", pos_weight if pos_weight is not None else None)
+
         self.bce = nn.BCEWithLogitsLoss(
-            weight=weight, pos_weight=pos_weight, reduction="none"
+            weight=self.weight,
+            pos_weight=self.pos_weight,
+            reduction="none",
         )
 
     def forward(self, inputs: Tensor, targets: Tensor) -> Tensor:


### PR DESCRIPTION
## Summary
- ensure weight and pos_weight are tensors in FocalLoss
- register them as buffers when constructing BCEWithLogitsLoss

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python - <<'EOF'
from hydra import compose, initialize
from hydra.utils import instantiate
initialize(version_base=None, config_path="configs/criterion")
cfg = compose(config_name="focal_pos_weight.yaml")
instantiate(cfg)
EOF` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68457d3809d883309f32e6df2e5dc225