### PR TITLE
Move criterion to device before training

### DIFF
--- a/siaug/train_convirt.py
+++ b/siaug/train_convirt.py
@@ -56,6 +56,9 @@ def main(cfg: DictConfig):
     model = cfg["model"].to(device)
     model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
+    # move the criterion to the correct device
+    criterion = cfg["criterion"].to(device)
+
     # optimizer
     print(f"=> Instantiating optimizer [device={device}]")
     params = model.get_param_groups() if hasattr(model, "get_param_groups") else model.parameters()
@@ -93,7 +96,7 @@ def main(cfg: DictConfig):
             accelerator=accelerator,
             dataloader=train_dataloader,
             model=model,
-            criterion=cfg["criterion"],
+            criterion=criterion,
             optimizer=optimizer,
             is_logging=is_logging,
             log_every_n_steps=cfg["log_every_n_steps"],
@@ -104,7 +107,7 @@ def main(cfg: DictConfig):
             accelerator=accelerator,
             dataloader=valid_dataloader,
             model=model,
-            criterion=cfg["criterion"],
+            criterion=criterion,
             is_logging=is_logging,
             log_every_n_steps=cfg["log_every_n_steps"],
             fast_dev_run=cfg["fast_dev_run"],

--- a/siaug/train_lcls.py
+++ b/siaug/train_lcls.py
@@ -55,6 +55,9 @@ def main(cfg: DictConfig):
     model = cfg["model"].to(device)
     model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
+    # move the criterion to the correct device
+    criterion = cfg["criterion"].to(device)
+
     # build optimizer from a partial optimizer
     print(f"=> Instantiating the optimizer [device={device}")
     params = list(filter(lambda p: p.requires_grad, model.parameters()))
@@ -95,7 +98,7 @@ def main(cfg: DictConfig):
             accelerator=accelerator,
             dataloader=train_dataloader,
             model=model,
-            criterion=cfg["criterion"],
+            criterion=criterion,
             optimizer=optimizer,
             metrics=cfg["metrics"],
             is_logging=is_logging,
@@ -111,7 +114,7 @@ def main(cfg: DictConfig):
             accelerator=accelerator,
             dataloader=valid_dataloader,
             model=model,
-            criterion=cfg["criterion"],
+            criterion=criterion,
             metrics=cfg["metrics"],
             is_logging=is_logging,
             log_every_n_steps=cfg["log_every_n_steps"],

--- a/siaug/train_repr.py
+++ b/siaug/train_repr.py
@@ -52,6 +52,9 @@ def main(cfg: DictConfig):
     model = cfg["model"].to(device)
     model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
+    # move the criterion to the correct device
+    criterion = cfg["criterion"].to(device)
+
     # optimizer
     # infer learning rate before changing the batch size
     print(f"=> Instantiating optimizer [device={device}]")
@@ -90,7 +93,7 @@ def main(cfg: DictConfig):
             accelerator=accelerator,
             dataloader=train_dataloader,
             model=model,
-            criterion=cfg["criterion"],
+            criterion=criterion,
             optimizer=optimizer,
             is_logging=is_logging,
             log_every_n_steps=cfg["log_every_n_steps"],


### PR DESCRIPTION
## Summary
- ensure loss criterion is moved to the accelerator device
- pass prepared criterion into training/evaluation loops

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68458482ccb88330a8d9be2ef821ff83