### PR TITLE
Add BloodMNIST backbone experiment configs

### DIFF
--- a/configs/experiment/repr_bloodmnist_base.yaml
+++ b/configs/experiment/repr_bloodmnist_base.yaml
@@ -1,0 +1,21 @@
+# @package _global_
+
+defaults:
+  - override /dataloader: bloodmnist.yaml
+
+# general settings
+task_name: ???
+
+dataloader:
+  train:
+    batch_size: 256
+    dataset:
+      com_transform:
+        _target_: siaug.augmentations.ExtractKeys
+        keys: ["img"]
+      img_transform: ???
+  valid: null
+
+model:
+  backbone: ???
+  num_channels: 3

--- a/configs/experiment/repr_bloodmnist_baseline.yaml
+++ b/configs/experiment/repr_bloodmnist_baseline.yaml
@@ -1,0 +1,65 @@
+# @package _global_
+
+defaults:
+  - repr_bloodmnist_base.yaml
+
+# general settings
+task_name: repr_bloodmnist_baseline
+
+dataloader:
+  train:
+    dataset:
+      img_transform:
+        _target_: siaug.augmentations.ToSiamese
+        t1:
+          _target_: torchvision.transforms.Compose
+          transforms:
+            - _target_: torchvision.transforms.RandomResizedCrop
+              size: 224
+              scale: [0.2, 1.]
+            - _target_: torchvision.transforms.RandomApply
+              p: 0.8
+              transforms:
+                - _target_: torchvision.transforms.ColorJitter
+                  brightness: 0.4
+                  contrast: 0.4
+                  saturation: 0.4
+                  hue: 0.1
+            - _target_: torchvision.transforms.RandomApply
+              p: 0.5
+              transforms:
+                - _target_: siaug.augmentations.simsiam.GaussianBlur
+                  sigma: [.1, 2.]
+            - _target_: torchvision.transforms.RandomHorizontalFlip
+            - _target_: torchvision.transforms.ToTensor
+            - _target_: torchvision.transforms.Normalize
+              mean: [0.5, 0.5, 0.5]
+              std: [0.5, 0.5, 0.5]
+        t2:
+          _target_: torchvision.transforms.Compose
+          transforms:
+            - _target_: torchvision.transforms.RandomResizedCrop
+              size: 224
+              scale: [0.2, 1.]
+            - _target_: torchvision.transforms.RandomApply
+              p: 0.8
+              transforms:
+                - _target_: torchvision.transforms.ColorJitter
+                  brightness: 0.4
+                  contrast: 0.4
+                  saturation: 0.4
+                  hue: 0.1
+            - _target_: torchvision.transforms.RandomApply
+              p: 0.5
+              transforms:
+                - _target_: siaug.augmentations.simsiam.GaussianBlur
+                  sigma: [.1, 2.]
+            - _target_: torchvision.transforms.RandomHorizontalFlip
+            - _target_: torchvision.transforms.ToTensor
+            - _target_: torchvision.transforms.Normalize
+              mean: [0.5, 0.5, 0.5]
+              std: [0.5, 0.5, 0.5]
+
+model:
+  backbone: resnet50
+  num_channels: 3


### PR DESCRIPTION
## Summary
- add a generic base experiment for BloodMNIST
- add baseline backbone training experiment for BloodMNIST

## Testing
- `pre-commit run --files configs/experiment/repr_bloodmnist_base.yaml configs/experiment/repr_bloodmnist_baseline.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684ae915e7808330a5ee8c336d3c6092