### PR TITLE
Update bloodmnist contrastive augmentations

### DIFF
--- a/configs/experiment/repr_bloodmnist_baseline.yaml
+++ b/configs/experiment/repr_bloodmnist_baseline.yaml
@@ -31,6 +31,7 @@ dataloader:
                 - _target_: siaug.augmentations.simsiam.GaussianBlur
                   sigma: [.1, 2.]
             - _target_: torchvision.transforms.RandomHorizontalFlip
+              p: 0.5
             - _target_: torchvision.transforms.ToTensor
             - _target_: torchvision.transforms.Normalize
               mean: [0.5, 0.5, 0.5]
@@ -40,7 +41,7 @@ dataloader:
           transforms:
             - _target_: torchvision.transforms.RandomResizedCrop
               size: 224
-              scale: [0.2, 1.]
+              scale: [0.4, 1.]
             - _target_: torchvision.transforms.RandomApply
               p: 0.8
               transforms:
@@ -53,8 +54,9 @@ dataloader:
               p: 0.5
               transforms:
                 - _target_: siaug.augmentations.simsiam.GaussianBlur
-                  sigma: [.1, 2.]
+                  sigma: [.2, 2.]
             - _target_: torchvision.transforms.RandomHorizontalFlip
+              p: 0.8
             - _target_: torchvision.transforms.ToTensor
             - _target_: torchvision.transforms.Normalize
               mean: [0.5, 0.5, 0.5]


### PR DESCRIPTION
## Summary
- vary `t2` crop scale and blur strength for bloodmnist baseline
- explicitly set flip probabilities for both chains

## Testing
- `pre-commit run --files configs/experiment/repr_bloodmnist_baseline.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684af04ee5b083309fdcfeb62b52566a